### PR TITLE
コルーチンではなくExecutorServiceを使って非同期で実行するように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 # testing
 .devcontainer
+
+monitor.log

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,6 +14,7 @@ tasks:
   up:
     desc: start the container
     cmds:
+      - nohup ./monitor_localstack.sh > monitor.log 2>&1 </dev/null &
       - docker compose up --watch --menu=false
 
   stop:

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     kotlin("jvm") version "2.0.0"
     kotlin("plugin.spring") version "2.0.0"
@@ -45,10 +47,10 @@ kotlin {
     }
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs = listOf("-Xjsr305=strict")
-        jvmTarget = "21"
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    compilerOptions {
+        freeCompilerArgs.add("-Xjsr305=strict")
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
 	implementation("software.amazon.awssdk:core:2.29.43")
 	implementation("software.amazon.awssdk:regions:2.29.43")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
 	implementation("org.slf4j:slf4j-api:2.1.0-alpha1")
 	runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -15,11 +15,6 @@ spring:
         format_sql: true
         globally_quoted_identifiers: true #予約済キーワードをエスケープするための構成
         globally_quoted_identifiers_skip_column_definitions: true
-  devtools:
-    restart:
-      enabled: true
-    livereload:
-      enabled: true
 postgres:
   url: ${POSTGRES_DATABASE_URL}
   username: ${POSTGRES_DATABASE_USER}

--- a/infra/docker/localstack/Dockerfile
+++ b/infra/docker/localstack/Dockerfile
@@ -1,1 +1,1 @@
-FROM localstack/localstack:4.0.3
+FROM localstack/localstack:4.2.0

--- a/infra/docker/localstack/init/init-aws.sh
+++ b/infra/docker/localstack/init/init-aws.sh
@@ -21,6 +21,51 @@ awslocal dynamodb create-table \
     --no-deletion-protection-enabled \
     --stream-specification StreamEnabled=true,StreamViewType=NEW_IMAGE
 
+# @see https://github.com/localstack/localstack/issues/10000
+awslocal dynamodb create-table \
+    --table-name sample-kcl-lease \
+    --attribute-definitions \
+        AttributeName=leaseOwner,AttributeType=S \
+        AttributeName=leaseKey,AttributeType=S \
+    --key-schema \
+        AttributeName=leaseKey,KeyType=HASH \
+    --billing-mode=PAY_PER_REQUEST \
+    --global-secondary-indexes \
+        '[
+            {
+                "IndexName": "LeaseOwnerToLeaseKeyIndex",
+                "KeySchema": [
+                    {
+                        "AttributeName": "leaseOwner",
+                        "KeyType": "HASH"
+                    },
+                    {
+                        "AttributeName": "leaseKey",
+                        "KeyType": "RANGE"
+                    }
+                ],
+                "Projection": {
+                    "ProjectionType": "KEYS_ONLY"
+                }
+            }
+        ]'
+
+awslocal dynamodb create-table \
+    --table-name sample-kcl-WorkerMetricStats \
+    --attribute-definitions \
+        AttributeName=wid,AttributeType=S \
+    --key-schema \
+        AttributeName=wid,KeyType=HASH \
+    --billing-mode=PAY_PER_REQUEST
+
+awslocal dynamodb create-table \
+    --table-name sample-kcl-CoordinatorState \
+    --attribute-definitions \
+        AttributeName=key,AttributeType=S \
+    --key-schema \
+        AttributeName=key,KeyType=HASH \
+    --billing-mode=PAY_PER_REQUEST
+
 # create dynamodb test用
 awslocal dynamodb create-table \
     --table-name animals_test \

--- a/monitor_localstack.sh
+++ b/monitor_localstack.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+LOCK_FILE="/tmp/monitor_localstack_running"
+SERVICE_NAME="localstack"
+
+# 既にスクリプトが動いているかチェック
+if [ -f "$LOCK_FILE" ]; then
+  echo "monitor_localstack.sh は既に実行中です。"
+  exit 0
+fi
+
+# 実行中フラグファイルを作成
+touch "$LOCK_FILE"
+
+# 無限ループでログを監視
+while true; do
+  # コンテナのログの末尾から新しいログを監視
+  docker compose logs --tail 100 -f $SERVICE_NAME 2>&1 | while read line; do
+    if echo "$line" | grep -q "An error occurred (ResourceNotFoundException) when calling the GetShardIterator operation: Unable to find record with provided SequenceNumber SequenceNumber(0) in stream Some"; then
+      echo "エラー検出: LocalStack を再起動します..."
+      docker compose down -v $SERVICE_NAME
+      docker compose up -d $SERVICE_NAME
+      break  # 再起動後にログ監視を終了して新たに監視を始める
+    fi
+  done
+  sleep 5  # 再起動後少し待ってから新たに監視を開始
+done
+
+# スクリプトが終了したらフラグファイルを削除
+rm -f "$LOCK_FILE"


### PR DESCRIPTION
## Summary
- KCLは内部でスレッド管理をしているため、コルーチンのDispathersと競合してしまい相性が悪いため、スレッド管理はJavaのスレッドプールを使用する
- localstackを使っていると #8 のエラーが発生し、コンシューマーアプリが時間経過したあとにエラーになってしまう
  - localstackでエラーをkinesisのエラーを検知した場合、削除して再起動をさせるようにシェルを追加
  - なお、再起動時にKCLがリーステーブルがないとエラーになってしまうため、localstackを使う場合はKCLで自動で作成されるテーブルは先に生成しておくようにする
  - https://docs.aws.amazon.com/ja_jp/streams/latest/dev/kcl-dynamoDB.html#kcl-leasetable

## Fix contents


### Supplementary information


## Confirmation method


## What I would like you to review


## Review Deadline


